### PR TITLE
Bug fixing

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -41,7 +41,7 @@
     </style>
   </head>
   <body>
-    <div class="progress" data-scroll data-scroll-progress></div>
+    <div class="progress" data-scroll data-scroll-progress data-scroll-fixed></div>
     <div data-scroll data-scroll-class="visible" data-scroll-position="top">Should turn green</div>
     <p>Auctor vivamus ac et condimentum himenaeos pretium parturient tincidunt sociosqu inceptos ullamcorper vitae placerat nisi facilisis odio molestie odio turpis venenatis. Nam a cras at ac nam vestibulum at adipiscing consectetur vestibulum aliquet penatibus diam potenti lacus porta. Potenti a potenti at dignissim a semper rhoncus consectetur ad vitae congue posuere a id. Dictumst donec vestibulum lectus quis in neque suspendisse urna nec mattis semper vestibulum justo a faucibus. Posuere rhoncus ad pulvinar a eget dui volutpat aliquam quam platea purus elit lorem ante. </p>
     <p>Rutrum aliquam vestibulum parturient eleifend vestibulum a a integer mollis cubilia commodo fermentum himenaeos a inceptos adipiscing a sapien ad. Ac id praesent hendrerit donec ad erat elit ullamcorper condimentum a nisi hac dui dui nec lacinia morbi nam potenti proin auctor parturient est cubilia. Augue parturient velit vehicula fermentum erat eu suspendisse parturient euismod a vulputate potenti proin a donec ultricies consectetur consectetur fringilla ullamcorper a nunc ridiculus nec. Laoreet ligula vestibulum parturient feugiat scelerisque ridiculus in nisl vestibulum justo scelerisque a a ut vitae scelerisque quis. </p>

--- a/example/index.html
+++ b/example/index.html
@@ -41,7 +41,7 @@
     </style>
   </head>
   <body>
-    <div class="progress" data-scroll data-scroll-progress data-scroll-fixed></div>
+    <div class="progress" data-scroll data-scroll-progress></div>
     <div data-scroll data-scroll-class="visible" data-scroll-position="top">Should turn green</div>
     <p>Auctor vivamus ac et condimentum himenaeos pretium parturient tincidunt sociosqu inceptos ullamcorper vitae placerat nisi facilisis odio molestie odio turpis venenatis. Nam a cras at ac nam vestibulum at adipiscing consectetur vestibulum aliquet penatibus diam potenti lacus porta. Potenti a potenti at dignissim a semper rhoncus consectetur ad vitae congue posuere a id. Dictumst donec vestibulum lectus quis in neque suspendisse urna nec mattis semper vestibulum justo a faucibus. Posuere rhoncus ad pulvinar a eget dui volutpat aliquam quam platea purus elit lorem ante. </p>
     <p>Rutrum aliquam vestibulum parturient eleifend vestibulum a a integer mollis cubilia commodo fermentum himenaeos a inceptos adipiscing a sapien ad. Ac id praesent hendrerit donec ad erat elit ullamcorper condimentum a nisi hac dui dui nec lacinia morbi nam potenti proin auctor parturient est cubilia. Augue parturient velit vehicula fermentum erat eu suspendisse parturient euismod a vulputate potenti proin a donec ultricies consectetur consectetur fringilla ullamcorper a nunc ridiculus nec. Laoreet ligula vestibulum parturient feugiat scelerisque ridiculus in nisl vestibulum justo scelerisque a a ut vitae scelerisque quis. </p>

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ class ScrollTrigger {
 
   calcBounds() {
     // Element is hidden and not fixed
-    if (!this.el.offsetParent && typeof this.options.fixed !== 'undefined') {
+    if (!this.el.offsetParent && typeof this.options.fixed === 'undefined') {
       // Don't even bother calculating
       this.disabled = true;
       return;

--- a/index.js
+++ b/index.js
@@ -40,6 +40,12 @@ class ScrollTrigger {
     on(this.el, 'scrolltriggers:resume', () => {
       this.paused = false;
     });
+
+    /*
+      Prevents a bug on Blink+Webkit in which scroll is always 0 until around
+      400 milliseconds due to anchor scrolling features.
+     */
+    setTimeout(this.eventHandler, 400);
   }
 
   calcBounds() {

--- a/index.js
+++ b/index.js
@@ -50,7 +50,8 @@ class ScrollTrigger {
 
   calcBounds() {
     // Element is hidden and not fixed
-    if (!this.el.offsetParent && typeof this.options.fixed === 'undefined') {
+    const isAllowedToBeFixed = this.options.progress === true || typeof this.options.fixed !== 'undefined';
+    if (!this.el.offsetParent && !isAllowedToBeFixed) {
       // Don't even bother calculating
       this.disabled = true;
       return;


### PR DESCRIPTION
While ensuring images that were hidden weren't downloaded I realised a couple of things.

## Fixed and hidden elements.

First one is that that feature wasn't working due a lousy check, it should check that `option.fixed` is undefined for the `disable` to be `true`. Due to this hidden elements were being checked nevertheless hence, downloading unnecessary images.

Since `fixed` elements don't have an `offsetParent` we need to add this to ensure we can add that class to every fixed element we want. Thanks to that bug I realised this was a breaking change since `scroll-progress` need said attribute to work normally otherwise they would be ignored. I've made so both elements would pass.

## Reload issue

While developing I realised that most of the times the scroll wouldn't trigger an animation or a class being appended and that's due to scroll anchoring in some browsers. I've added a new timeout that seems to, reliably, get the proper scroll after page load so everything seems to be updating correctly after that.